### PR TITLE
Dependency update, SpringBoot and Cloud Gateway Updates, few fixes.

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build VuePress
 on: [push]
 jobs:
   build-and-deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 17
 
       - name: Get version name
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 15
+        java-version: 17
     - name: Build with Maven
       run: mvn -B package --file oag/pom.xml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Build stage
 #
-FROM maven:3.8.4-openjdk-17 AS build
+FROM maven:3.8.8-amazoncorretto-17 AS build
 
 # Copy POM file and download dependencies -> allows faster build because this step can be cached
 COPY oag/pom.xml /home/app/pom.xml
@@ -16,7 +16,7 @@ RUN mvn package -f /home/app/pom.xml
 # Package stage
 #
 # FROM openjdk:18-oraclelinux8
-FROM amazoncorretto:17.0.7-alpine3.17
+FROM amazoncorretto:17.0.9-alpine3.18
 
 # for regular linux 
 # RUN useradd --user-group --system --create-home --no-log-init app

--- a/oag/pom.xml
+++ b/oag/pom.xml
@@ -6,13 +6,13 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <!-- updating the version needs also updating spring-cloud.version see below. -->
-        <version>2.6.14</version>
+        <version>3.2.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <groupId>org.owasp</groupId>
     <artifactId>oag</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.6-SNAPSHOT</version>
 
     <name>OWASP Application Gateway</name>
     <description>An elephant strong web application gateway that handles oauth2 authentication and session management.
@@ -54,7 +54,7 @@
     <properties>
         <java.version>11</java.version>
         <!-- updating this version needs also updating the parent, see https://spring.io/projects/spring-cloud -->
-        <spring-cloud.version>2021.0.7</spring-cloud.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
     </properties>
 
     <dependencies>
@@ -67,46 +67,33 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>33.0.0-jre</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.91.Final</version>
+            <version>2.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk -->
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>10.9</version>
-        </dependency>
-
-        <!-- imported by com.nimbus avove -->
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.4.10</version>
+            <version>11.8</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt -->
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.31</version>
+            <version>9.37.3</version>
         </dependency>
 
         <dependency>
@@ -119,19 +106,19 @@
         <dependency>
             <groupId>org.mapdb</groupId>
             <artifactId>mapdb</artifactId>
-            <version>3.0.9</version>
+            <version>3.0.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>ST4</artifactId>
-            <version>4.3.1</version>
+            <version>4.3.4</version>
             <scope>compile</scope>
         </dependency>
 
@@ -139,7 +126,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.0.6</version>
+            <version>3.1.8</version>
         </dependency>
 
         <dependency>
@@ -167,20 +154,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <version>3.0.1</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
@@ -188,7 +173,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-contract-wiremock</artifactId>
-            <version>3.1.6 </version>
+            <version>4.1.0 </version>
             <scope>test</scope>
         </dependency>
 
@@ -234,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
@@ -243,7 +228,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -257,7 +242,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -275,7 +260,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -310,7 +295,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/oag/pom.xml
+++ b/oag/pom.xml
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <!-- updating this version needs also updating the parent, see https://spring.io/projects/spring-cloud -->
         <spring-cloud.version>2023.0.0</spring-cloud.version>
     </properties>

--- a/oag/src/main/java/org/owasp/oag/filters/proxy/CsrfValidationFilter.java
+++ b/oag/src/main/java/org/owasp/oag/filters/proxy/CsrfValidationFilter.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -36,9 +37,8 @@ public class CsrfValidationFilter extends RouteAwareFilter {
         var securityProfile = routeContext.getSecurityProfile();
 
         // Load security profile
-        String reqMethod = exchange.getRequest().getMethodValue();
-        boolean isSafeMethod = securityProfile.getCsrfSafeMethods()
-                .contains(reqMethod);
+        HttpMethod reqMethod = exchange.getRequest().getMethod();
+        boolean isSafeMethod = securityProfile.getCsrfSafeMethods().contains(reqMethod.name());
 
         if (!isSafeMethod) {
 

--- a/oag/src/main/java/org/owasp/oag/filters/proxy/MethodWhitelistFilter.java
+++ b/oag/src/main/java/org/owasp/oag/filters/proxy/MethodWhitelistFilter.java
@@ -23,10 +23,10 @@ public class MethodWhitelistFilter extends RouteAwareFilter {
 
         logTrace(log, exchange, "Execute MethodWhitelistFilter");
 
-        var reqMethod = exchange.getRequest().getMethodValue();
+        var reqMethod = exchange.getRequest().getMethod();
         var allowedMethods = routeContext.getSecurityProfile().getAllowedMethods();
 
-        boolean isAllowed = allowedMethods.contains(reqMethod);
+        boolean isAllowed = allowedMethods.contains(reqMethod.name());
 
         if (!isAllowed) {
 

--- a/oag/src/main/java/org/owasp/oag/filters/spring/SimpleLogFilter.java
+++ b/oag/src/main/java/org/owasp/oag/filters/spring/SimpleLogFilter.java
@@ -1,5 +1,6 @@
 package org.owasp.oag.filters.spring;
 
+import org.jetbrains.annotations.NotNull;
 import org.owasp.oag.utils.LoggingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,8 +18,9 @@ public class SimpleLogFilter implements WebFilter {
 
     private static final Logger log = LoggerFactory.getLogger(SimpleLogFilter.class);
 
+    @NotNull
     @Override
-    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    public Mono<Void> filter(@NotNull ServerWebExchange exchange, WebFilterChain chain) {
 
         LoggingUtils.logTrace(log, exchange, "Execute SimpleLogFilter");
 
@@ -31,15 +33,15 @@ public class SimpleLogFilter implements WebFilter {
                 .doOnSuccess((u) -> {
                     var response = exchange.getResponse();
                     LoggingUtils.logInfo(log, exchange, "Response status code {} for {} {}",
-                            response.getRawStatusCode(),
-                            request.getMethodValue(),
+                            response.getStatusCode(),
+                            request.getMethod(),
                             request.getURI());
                 })
                 .doOnError(ResponseStatusException.class, e -> {
 
                     LoggingUtils.logInfo(log, exchange, "Response status code {} for {} {} errorReason: '{}'",
-                            e.getRawStatusCode(),
-                            request.getMethodValue(),
+                            e.getStatusCode(),
+                            request.getMethod(),
                             request.getURI(),
                             e.getReason());
                     throw e;

--- a/oag/src/main/java/org/owasp/oag/filters/spring/TraceContextFilter.java
+++ b/oag/src/main/java/org/owasp/oag/filters/spring/TraceContextFilter.java
@@ -1,5 +1,6 @@
 package org.owasp.oag.filters.spring;
 
+import org.jetbrains.annotations.NotNull;
 import org.owasp.oag.logging.TraceContextBridge;
 import org.owasp.oag.utils.LoggingUtils;
 import org.slf4j.Logger;
@@ -12,14 +13,13 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
-@Order(-10)
-@Component
 /**
  *  Responsible to setup a trace id based on the configured Trace mechanism.
  *
  *  The trace id is made available in the reactive context and to the log implementation when using the LoggingUtils.
- *  See
  */
+@Order(-10)
+@Component
 public class TraceContextFilter implements WebFilter {
 
     final Logger log = LoggerFactory.getLogger(TraceContextFilter.class);
@@ -31,20 +31,19 @@ public class TraceContextFilter implements WebFilter {
     @Autowired
     TraceContextBridge traceContext;
 
+    @NotNull
     @Override
-    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain webFilterChain) {
+    public Mono<Void> filter(@NotNull ServerWebExchange exchange, WebFilterChain webFilterChain) {
 
         // Get trace id
         exchange = traceContext.processExchange(exchange);
 
         String possibleTraceId = exchange.getAttribute(TRACE_ID_CONTEXT_KEY);
-        final String traceId = possibleTraceId == null ? "n/a" : possibleTraceId;
+        final String traceId = possibleTraceId == null ? "noTraceIdProvided" : possibleTraceId;
 
         // Add request id to subscription context and make a log statement
         return Mono.just(traceId)
-                .doOnEach(LoggingUtils.logOnNext(s -> {
-                    log.debug("Generated new request id.");
-                }))
+                .doOnEach(LoggingUtils.logOnNext(s -> log.debug("Generated new request id.")))
                 .then(webFilterChain.filter(exchange))
                 .contextWrite(c -> c.put(TRACE_ID_CONTEXT_KEY, traceId));
     }

--- a/oag/src/main/java/org/owasp/oag/logging/TraceContextBridge.java
+++ b/oag/src/main/java/org/owasp/oag/logging/TraceContextBridge.java
@@ -53,11 +53,13 @@ public class TraceContextBridge {
         // Add trace id to downstream request
         if (requestContext.sendTraceDownstream()) {
             LoggingUtils.logDebug(log, exchange, "Added trace id to downstream call.");
-            var mutatedRequest = exchange.getRequest().mutate()
-                    .header(requestContext.getMainRequestHeader(), requestContext.getTraceString())
-                    .header(requestContext.getSecondaryRequestHeader(), requestContext.getSecondaryTraceInfoString()).build();
+            var mutatedRequest = exchange.getRequest().mutate();
+            mutatedRequest.header(requestContext.getMainRequestHeader(), requestContext.getTraceString());
+            if(requestContext.acceptAdditionalTraceInfo()) {
+                mutatedRequest.header(requestContext.getSecondaryRequestHeader(), requestContext.getSecondaryTraceInfoString());
+            }
 
-            exchange = exchange.mutate().request(mutatedRequest).build();
+            exchange = exchange.mutate().request(mutatedRequest.build()).build();
         }
 
         // Add trace id to response

--- a/oag/src/main/java/org/owasp/oag/logging/simpleTrace/SimpleTraceContext.java
+++ b/oag/src/main/java/org/owasp/oag/logging/simpleTrace/SimpleTraceContext.java
@@ -74,7 +74,7 @@ public class SimpleTraceContext implements TraceContext {
 
     @Override
     public String getSecondaryRequestHeader() {
-        return "n/a";
+        return "noUsedSecondaryRequestHeader";
     }
 
     @Override

--- a/oag/src/main/java/org/owasp/oag/services/keymgm/CurrentSigningKeyHolder.java
+++ b/oag/src/main/java/org/owasp/oag/services/keymgm/CurrentSigningKeyHolder.java
@@ -46,7 +46,6 @@ public class CurrentSigningKeyHolder {
      *
      * @param kid           the kid of the new key
      * @param newSigningKey the new signing key for JWTs
-     * @return the kid of the new signing key
      */
     public synchronized void setCurrentSigningKey(String kid, KeyGenerator.GeneratedKey newSigningKey) {
         if (newSigningKey == null) {

--- a/oag/src/main/java/org/owasp/oag/services/keymgm/DefaultKeyRotation.java
+++ b/oag/src/main/java/org/owasp/oag/services/keymgm/DefaultKeyRotation.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -44,9 +44,10 @@ public class DefaultKeyRotation implements KeyRotation {
     private void startScheduler() {
         try {
             if (config.getKeyManagementProfile().getKeyRotationProfile().getUseSigningKeyRotation()) {
-                scheduler.schedule(new RotateKeyTask(), new Date(System.currentTimeMillis() + config.getKeyManagementProfile().getKeyRotationProfile().getSigningKeyRotationSeconds() * 1000));
+                scheduler.schedule(new RotateKeyTask(), Instant.ofEpochMilli(System.currentTimeMillis() + config.getKeyManagementProfile().getKeyRotationProfile().getSigningKeyRotationSeconds() * 1000));
             } else {
-                scheduler.schedule(new RetrySchedulingTask(), new Date(System.currentTimeMillis() + 1 * 60 * 60 * 1000)); // retry scheduling, maybe config changed in the mean time
+                //noinspection PointlessArithmeticExpression
+                scheduler.schedule(new RetrySchedulingTask(), Instant.ofEpochMilli(System.currentTimeMillis() + 1 * 60 * 60 * 1000)); // retry scheduling, maybe config changed in the mean time
             }
         } catch (Exception e) {
             throw new ConsistencyException("Could not start scheduler of signing key rotation.", e);
@@ -59,7 +60,7 @@ public class DefaultKeyRotation implements KeyRotation {
         String kid = UUID.randomUUID().toString();
         long expiry = System.currentTimeMillis();
         if (config.getKeyManagementProfile().getKeyRotationProfile().getUseSigningKeyRotation()) {
-            expiry += (config.getKeyManagementProfile().getKeyRotationProfile().getSigningKeyRotationSeconds() + 600) * 1000;
+            expiry += (config.getKeyManagementProfile().getKeyRotationProfile().getSigningKeyRotationSeconds() + 600L) * 1000;
         } else {
             expiry = Integer.MAX_VALUE;
         }

--- a/oag/src/main/java/org/owasp/oag/services/login/drivers/oauth/Oauth2Driver.java
+++ b/oag/src/main/java/org/owasp/oag/services/login/drivers/oauth/Oauth2Driver.java
@@ -88,7 +88,7 @@ public abstract class Oauth2Driver extends LoginDriverBase {
             if (scopes instanceof String[])
                 return new Scope((String[]) scopes);
 
-            List<String> scopesList = (List<String>) scopes;
+            @SuppressWarnings("unchecked") List<String> scopesList = (List<String>) scopes;
             return new Scope(scopesList.toArray(new String[]{}));
 
         } catch (Exception e) {
@@ -198,8 +198,7 @@ public abstract class Oauth2Driver extends LoginDriverBase {
             throw new AuthenticationException(message);
         }
 
-        var tokens = tokenResponse.toSuccessResponse().getTokens();
-        return tokens;
+        return tokenResponse.toSuccessResponse().getTokens();
     }
 
     protected abstract UserModel loadUserInfo(Tokens accessToken);

--- a/oag/src/main/java/org/owasp/oag/session/UserModel.java
+++ b/oag/src/main/java/org/owasp/oag/session/UserModel.java
@@ -30,7 +30,7 @@ public class UserModel {
     /**
      * Creates a new user model with a user-id.
      *
-     * @param id
+     * @param id The user id
      */
     public UserModel(String id) {
         this.id = id;
@@ -40,7 +40,7 @@ public class UserModel {
     /**
      * Gets the unique id of the user
      *
-     * @return
+     * @return the user id
      */
     public String getId() {
         return id;
@@ -49,16 +49,15 @@ public class UserModel {
     /**
      * Should only be used for deserializing
      *
-     * @param id
+     * @param id the user id
      */
     public void setId(String id) {
         this.id = id;
     }
 
     /**
-     * Returns the user mappings map
      *
-     * @return
+     * @return Returns the user mappings map
      */
     public HashMap<String, String> getMappings() {
         return mappings;
@@ -67,7 +66,7 @@ public class UserModel {
     /**
      * Should only be used for deserializing
      *
-     * @param id
+     * @param mappings the mappings
      */
     public void setMappings(HashMap<String, String> mappings) {
         this.mappings = mappings;
@@ -76,8 +75,8 @@ public class UserModel {
     /**
      * Sets a specific user mapping
      *
-     * @param key
-     * @param value
+     * @param key the key
+     * @param value the value
      */
     public void set(String key, String value) {
         mappings.put(key, value);
@@ -86,8 +85,8 @@ public class UserModel {
     /**
      * Gets the value of a user mapping
      *
-     * @param key
-     * @return
+     * @param key the key
+     * @return the mapping
      */
     public String get(String key) {
         return mappings.get(key);

--- a/oag/src/main/java/org/owasp/oag/utils/SettingsUtils.java
+++ b/oag/src/main/java/org/owasp/oag/utils/SettingsUtils.java
@@ -9,13 +9,12 @@ import java.util.Map;
 
 public class SettingsUtils {
 
-    public static <T> T settingsFromMap(Map<String, Object> map, Class clazz) {
+    public static <T> T settingsFromMap(Map<String, Object> map, Class<T> clazz) {
 
         try {
             ObjectMapper om = new ObjectMapper(new YAMLFactory());
             String combinedConfigStr = om.writeValueAsString(map);
-            T config = (T) om.readValue(combinedConfigStr, clazz);
-            return config;
+            return om.readValue(combinedConfigStr, clazz);
         } catch (JsonProcessingException ex) {
 
             throw new ConfigurationException("Could not load settings", ex);

--- a/oag/src/test/java/org/owasp/oag/integration/DefaultConfigurationTest.java
+++ b/oag/src/test/java/org/owasp/oag/integration/DefaultConfigurationTest.java
@@ -12,8 +12,7 @@ import java.time.Duration;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {"spring.main.allow-bean-definition-overriding=true", "logging.level.org.owasp.oag=TRACE"},
-        classes = {IntegrationTestConfig.class})
+        properties = {"spring.main.allow-bean-definition-overriding=true", "logging.level.org.owasp.oag=TRACE"})
 public class DefaultConfigurationTest {
 
     @Autowired

--- a/oag/src/test/java/org/owasp/oag/integration/LoginProvidorValidationTest.java
+++ b/oag/src/test/java/org/owasp/oag/integration/LoginProvidorValidationTest.java
@@ -1,16 +1,20 @@
 package org.owasp.oag.integration;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.owasp.oag.config.configuration.LoginProvider;
 import org.owasp.oag.config.configuration.LoginProviderSettings;
-import org.owasp.oag.integration.testInfrastructure.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-class LoginProvidorValidationTest extends IntegrationTest {
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"spring.main.allow-bean-definition-overriding=true", "logging.level.org.owasp.oag=TRACE"})
+class LoginProvidorValidationTest {
 
     @Autowired
     ApplicationContext context;
@@ -31,7 +35,7 @@ class LoginProvidorValidationTest extends IntegrationTest {
         var errors = provider.getErrors(context);
 
         // Assert
-        assertEquals(0, errors.size(), "Errors: " + errors.toString());
+        assertEquals(0, errors.size(), "Errors: " + errors);
     }
 
     @Test
@@ -70,6 +74,6 @@ class LoginProvidorValidationTest extends IntegrationTest {
         var errors = provider.getErrors(context);
 
         // Assert
-        assertTrue(!errors.isEmpty(), "Expected errors with invalid configuration");
+        assertFalse(errors.isEmpty(), "Expected errors with invalid configuration");
     }
 }

--- a/www/docs/docs/README.md
+++ b/www/docs/docs/README.md
@@ -6,6 +6,12 @@ OWASP Application Gateway is an HTTP reverse proxy that sits between your web ap
 
 ![](./images/OAG-Overview.png)
 
+## Prerequisites
+OAG builds on Top of (Minimum Requirements):
+- Java 17
+- SpringBoot 3.2.x
+- Spring Cloud Gateway 2023.x.y
+
 ## Design Principles
 
 ### Secure by default

--- a/www/docs/docs/Setup-for-OAG-development.md
+++ b/www/docs/docs/Setup-for-OAG-development.md
@@ -1,7 +1,7 @@
 # Setup for OAG development
 
 ## Preparation
-* Install Java 11 or higher
+* Install Java 17 or higher
 * Install Maven
 * Install Git
 * Install IntelliJ (Community Version is fine)


### PR DESCRIPTION
- Updated To Spring-Cloud 2023.0.0
- Spdated To Spring Boot 3.2.1
- dependency Updates to fix security issues
- Fixed an issue with Secondary Trace-Header (where in the simple trace case an invalid header of "n/a" was tried to be added to downstream requests.
- (new WARN log entries of Type: "...is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor..." are related to SpringBoot 3.2.1 and an known issue (https://github.com/spring-cloud/spring-cloud-commons/issues/1315) -
Fixing dependencies / vulnerabilities